### PR TITLE
Issue #24 - Modify ContentType to handle Relative Quality Factors

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/impl/ContentType.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/impl/ContentType.java
@@ -1,13 +1,19 @@
 package com.theoryinpractise.halbuilder.impl;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class ContentType {
     private String type;
     private String subType;
 
     public ContentType(String contentType) {
-        String[] parts = contentType.split("/");
-        type = parts[0];
-        subType = parts[1];
+        Pattern contentTypePattern = Pattern.compile("([\\w|\\*]*)/([^;,\\s]*)");
+        Matcher matcher = contentTypePattern.matcher(contentType);
+        if (matcher.find()) {
+            type = matcher.group(1);
+            subType = matcher.group(2);
+        }
     }
 
     public String getType() {

--- a/src/test/java/com/theoryinpractise/halbuilder/ContentTypeTest.java
+++ b/src/test/java/com/theoryinpractise/halbuilder/ContentTypeTest.java
@@ -12,7 +12,11 @@ public class ContentTypeTest {
     public void testContentTypeCreation() {
         Assertions.assertThat(new ContentType("application/xml").getType()).isEqualTo("application");
         assertThat(new ContentType("application/xml").getSubType()).isEqualTo("xml");
-    }
+        assertThat(new ContentType("{application/hal+json, q=1000}").getType()).isEqualTo("application");
+        assertThat(new ContentType("{application/hal+json, q=1000}").getSubType()).isEqualTo("hal+json");
+        assertThat(new ContentType("*/json").getType()).isEqualTo("*");
+        assertThat(new ContentType("*/json").getSubType()).isEqualTo("json");
+  }
 
     @Test
     public void testContentTypeMatching() {
@@ -22,6 +26,16 @@ public class ContentTypeTest {
         assertThat(new ContentType("application/xml").matches(new ContentType("*/xml"))).isTrue();
         assertThat(new ContentType("application/xml").matches(new ContentType("*/json"))).isFalse();
         assertThat(new ContentType("*/*").matches(new ContentType("application/xml"))).isFalse();
+        assertThat(new ContentType("application/json").matches(new ContentType("{application/json; q=1000}"))).isTrue();
+        assertThat(new ContentType("application/json").matches(new ContentType("{application/json;q=1000}"))).isTrue();
+        assertThat(new ContentType("application/json").matches(new ContentType("{application/json, q=1000}"))).isTrue();
+        assertThat(new ContentType("application/json").matches(new ContentType("{application/json,q=1000}"))).isTrue();
+        assertThat(new ContentType("application/hal+json").matches(new ContentType("{application/hal+json; q=1000}"))).isTrue();
+        assertThat(new ContentType("application/hal+json").matches(new ContentType("{application/hal+json;q=1000}"))).isTrue();
+        assertThat(new ContentType("application/hal+json").matches(new ContentType("{application/hal+json, q=1000}"))).isTrue();
+        assertThat(new ContentType("application/hal+json").matches(new ContentType("{application/hal+json,q=1000}"))).isTrue();
+        assertThat(new ContentType("application/hal+json").matches(new ContentType("{*/hal+json ,q=1000}"))).isTrue();
+        assertThat(new ContentType("*/*").matches(new ContentType("{application/hal+json ,q=1000}"))).isFalse();
     }
 
 }


### PR DESCRIPTION
Change from simply splitting the `contentString` to use
regex to match any word characters or `*` for the type and
match any character not a `;` or `,` or whitespace for the
subtype.

Add appropriate unit tests as well.

[Link to Header Field Definition](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) with
more information regarding relative quality factors.
